### PR TITLE
feat: コンパイル時エラーを返すように

### DIFF
--- a/compiler.jsonc
+++ b/compiler.jsonc
@@ -1,4 +1,3 @@
 {
-  "compilers": [
-  ]
+  "compilers": []
 }

--- a/main.ts
+++ b/main.ts
@@ -62,14 +62,14 @@ app.post("/code/:id/compile", async (c) => {
 
   if (!id) {
     return c.json({
-      status: "failed to compile",
+      status: "invalid id",
       id: "",
     }, 400);
   }
 
   if (!v4.validate(id)) {
     return c.json({
-      status: "failed to compile",
+      status: "invalid id",
       id: "",
     }, 400);
   }
@@ -90,14 +90,21 @@ app.post("/code/:id/compile", async (c) => {
         `./files/input/${id}.rb`,
       ],
     });
-
     const output = await a.output();
+
+    if (output.code !== 0) {
+      return c.json({
+        status: "error",
+        error: new TextDecoder().decode(output.stderr),
+      })
+    }
+
     const bin = await Deno.readFile(`./files/output/${id}.out`);
     const encodedBin = encodeBase64(bin);
 
     return c.json({
-      binary: encodedBin,
-      error: new TextDecoder().decode(output.stderr),
+      status: "ok",
+      binary: encodedBin
     });
   } catch (e) {
     console.log(e);

--- a/main.ts
+++ b/main.ts
@@ -9,6 +9,7 @@ const compilers = Deno.readTextFileSync("./compiler.jsonc");
 const Conpilers = JSON.parse(compilers) as {
   compilers: { path: string; version: string }[];
 };
+const INPUT_DIR_PATH = "./files/input/";
 
 app.use(
   "/*",
@@ -95,7 +96,7 @@ app.post("/code/:id/compile", async (c) => {
     if (output.code !== 0) {
       return c.json({
         status: "error",
-        error: new TextDecoder().decode(output.stderr),
+        error: new TextDecoder().decode(output.stderr).replace(INPUT_DIR_PATH, "").replace(`${id}.rb`, "input"),
       })
     }
 

--- a/main.ts
+++ b/main.ts
@@ -1,141 +1,143 @@
-import {Hono} from "@hono/hono";
-import {cors} from "@hono/hono/cors"
-import {decodeBase64, encodeBase64,} from "@std/encoding";
-import {v4} from "@std/uuid";
+import { Hono } from "@hono/hono";
+import { cors } from "@hono/hono/cors";
+import { decodeBase64, encodeBase64 } from "@std/encoding";
+import { v4 } from "@std/uuid";
 
 const app = new Hono();
 
 const compilers = Deno.readTextFileSync("./compiler.jsonc");
 const Conpilers = JSON.parse(compilers) as {
-    compilers: { path: string; version: string }[];
+  compilers: { path: string; version: string }[];
 };
 
 app.use(
-    "/*",
-    cors({
-        origin: "*",
-    }),
+  "/*",
+  cors({
+    origin: "*",
+  }),
 );
 
 app.get("/versions", (c) => {
-    return c.json(Conpilers.compilers.map((v) => {
-        return { version: v.version };
-    }));
+  return c.json(Conpilers.compilers.map((v) => {
+    return { version: v.version };
+  }));
 });
 
+/**
+ * コードをアップロード
+ */
 app.post("/code", async (c) => {
-    const body = await c.req.json() as { code: string };
-    const code = body.code;
+  const body = await c.req.json() as { code: string };
+  const code = body.code;
 
-    if (!code) {
-        c.status(400);
-        return c.json({ error: "invalid code" });
+  if (!code) {
+    return c.json({ error: "invalid code" }, 400);
+  }
+
+  const decoded = decodeBase64(code);
+
+  const id = crypto.randomUUID();
+
+  try {
+    await Deno.writeFile(`./files/input/${id}.rb`, decoded);
+  } catch {
+    return c.json({
+      status: "failed to write file",
+      id: "",
+    }, 500);
+  }
+
+  return c.json({
+    status: "ok",
+    id: id,
+  });
+});
+
+/**
+ * コードをコンパイル
+ */
+app.post("/code/:id/compile", async (c) => {
+  const id = (c.req.param() as { id: string }).id;
+  const { version } = await c.req.json() as { version: string };
+
+  if (!id) {
+    return c.json({
+      status: "failed to compile",
+      id: "",
+    }, 400);
+  }
+
+  if (!v4.validate(id)) {
+    return c.json({
+      status: "failed to compile",
+      id: "",
+    }, 400);
+  }
+
+  try {
+    const compilerPath = Conpilers.compilers.find((v) => v.version === version);
+    if (!compilerPath) {
+      return c.json({
+        status: "unknown compiler version",
+        id: "",
+      }, { status: 400 });
     }
 
-    const decoded = decodeBase64(code);
+    const a = new Deno.Command(compilerPath.path, {
+      args: [
+        "-o",
+        `./files/output/${id}.out`,
+        `./files/input/${id}.rb`,
+      ],
+    });
 
-    const id = crypto.randomUUID();
-
-    try {
-        await Deno.writeFile(`./files/input/${id}.rb`, decoded);
-    } catch {
-        c.status(500);
-        return c.json({
-            status: "failed to write file",
-            id: "",
-        });
-    }
+    const output = await a.output();
+    const bin = await Deno.readFile(`./files/output/${id}.out`);
+    const encodedBin = encodeBase64(bin);
 
     return c.json({
-        status: "ok",
-        id: id,
+      binary: encodedBin,
+      error: new TextDecoder().decode(output.stderr),
     });
+  } catch (e) {
+    console.log(e);
+    return c.json({
+      status: "failed to compile",
+      id: "",
+    }, 500);
+  }
 });
 
-app.post("/code/:id/compile", async (c) => {
-    const id = (c.req.param() as { id: string }).id;
-    const { version } = await c.req.json() as { version: string };
-
-    if (!id) {
-        c.status(400);
-        return c.json({
-            status: "failed to compile",
-            id: "",
-        });
-    }
-
-    if (!v4.validate(id)) {
-        c.status(400);
-        return c.json({
-            status: "failed to compile",
-            id: "",
-        });
-    }
-
-    try {
-        const compilerPath = Conpilers.compilers.find((v) => v.version === version);
-        if (!compilerPath) {
-            return c.json({
-                status: "unknown compiler version",
-                id: ""
-            }, { status: 400})
-        }
-
-        const a = new Deno.Command(compilerPath.path, {
-            args: [
-                "-o",
-                `./files/output/${id}.out`,
-                `./files/input/${id}.rb`,
-            ],
-        });
-
-        const output = await a.output();
-        const bin = await Deno.readFile(`./files/output/${id}.out`);
-        const encodedBin = encodeBase64(bin);
-
-        return c.json({
-            binary: encodedBin,
-            error: new TextDecoder().decode(output.stderr),
-        });
-    } catch (e) {
-        console.log(e);
-        c.status(500);
-        return c.json({
-            status: "failed to compile",
-            id: "",
-        });
-    }
-});
-
+/**
+ * コードの存在チェック
+ */
 app.get("/code/:id", async (c) => {
-    const id = (c.req.param() as { id: string }).id;
+  const id = (c.req.param() as { id: string }).id;
 
-    if (!id) {
-        c.status(400);
-        return c.json({ error: "invalid id" });
-    }
+  if (!id) {
+    return c.json({ error: "invalid id" }, 400);
+  }
 
-    if (!v4.validate(id)) {
-        c.status(400);
-        return c.json({
-            error: "invalid id",
-        });
-    }
+  if (!v4.validate(id)) {
+    c.status(400);
+    return c.json({
+      error: "invalid id",
+    }, 400);
+  }
 
-    try {
-        const data = await Deno.readFile(`./files/input/${id}.rb`);
-        const encodedCode = encodeBase64(data);
+  try {
+    const data = await Deno.readFile(`./files/input/${id}.rb`);
+    const encodedCode = encodeBase64(data);
 
-        return c.json({
-            code: encodedCode,
-        });
-    } catch (e) {
-        console.log(e);
-        c.status(500);
-        return c.json({
-            error: "internal error",
-        });
-    }
+    return c.json({
+      code: encodedCode,
+    });
+  } catch (e) {
+    console.log(e);
+    return c.json({
+      error: "internal error",
+    }, 400);
+  }
 });
 
 Deno.serve(app.fetch);

--- a/readme.md
+++ b/readme.md
@@ -75,4 +75,3 @@
   "error": "<compiler output>"
 }
 ```
-

--- a/readme.md
+++ b/readme.md
@@ -67,11 +67,40 @@
 
 #### Response
 
+`200 OK`  
+コンパイル成功時
+```json
+{
+  "status": "ok",
+  "binary": "<base64 encoded mruby/c binary>"
+}
+```
+
 `200 OK`
+コンパイル失敗時
 
 ```json
 {
-  "binary": "<base64 encoded mruby/c binary>",
-  "error": "<compiler output>"
+  "status": "error",
+  "error": "<error message>"
+}
+```
+
+`400 Bad Request`
+```jsonc
+{
+  // "invalid id" or "unknown compiler version"
+  "status": "<error code>"
+  // 常に空
+  "id": "",
+ }
+```
+
+`500 Internal Error`  
+他の原因で失敗した場合:
+```json
+{
+  "status": "failed to compile",
+  "id": ""
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,13 @@
   "error": "<error message>"
 }
 ```
+例:
+```json
+{
+  "status": "error",
+  "error": "input:4:0: syntax error, unexpected end of file, expecting \"'end'\"\n"
+}
+```
 
 `400 Bad Request`
 ```jsonc


### PR DESCRIPTION
## やったこと
close #6 
- コンパイル失敗してもバイナリが返されることがある現象を修正
- コンパイル用エンドポイントが返すエラーの形式を修正
  - いくつか破壊的変更が入っています
- コンパイルエラーに含まれるパスをマスクするように